### PR TITLE
Implement 3DST (Nintendo Anime Channel) support

### DIFF
--- a/Ohana3DS Rebirth/Ohana/FileIO.cs
+++ b/Ohana3DS Rebirth/Ohana/FileIO.cs
@@ -71,6 +71,11 @@ namespace Ohana3DS_Rebirth.Ohana
                     return new file { data = mdls, type = formatType.model };
             }
 
+            switch (getMagic(input, 7))
+            {
+                case "texture": return new file { data = _3DST.load(data), type = formatType.image };
+            }
+
             switch (getMagic(input, 5))
             {
                 case "MODEL": return new file { data = DQVIIPack.load(data), type = formatType.container };

--- a/Ohana3DS Rebirth/Ohana/Textures/3DST.cs
+++ b/Ohana3DS Rebirth/Ohana/Textures/3DST.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Drawing;
+using System.IO;
+
+namespace Ohana3DS_Rebirth.Ohana.Textures
+{
+    class _3DST
+    {
+        /// <summary>
+        ///     Loads a 3DST Nintendo Anime Channel image.
+        /// </summary>
+        /// <param name="data">The 3DST image data</param>
+        /// <returns>The image as a texture</returns>
+        public static RenderBase.OTexture load(Stream data)
+        {
+            BinaryReader input = new BinaryReader(data);
+
+            // A 3DST image contains the word 'texture' at the beggining of the file, followed by 9 null bytes
+            string _3dstMagic = IOUtils.readStringWithLength(input, 7);
+            if (_3dstMagic != "texture") throw new Exception("3DST: Invalid or corrupted file!");
+            input.ReadUInt32();
+            input.ReadUInt32();
+            input.ReadByte();
+
+            // Next, we have the width and height and finally, the image format
+            ushort width = input.ReadUInt16();
+            ushort height = input.ReadUInt16();
+            ushort format = input.ReadUInt16();
+
+            // Depending of the image format, the length of it is calculated differently
+            int length = 0;
+            RenderBase.OTextureFormat OTextureFormat = RenderBase.OTextureFormat.dontCare;
+            switch(format)
+            {
+                case 0:
+                    length = width * height * 4;
+                    OTextureFormat = RenderBase.OTextureFormat.rgba8;
+                    break;
+                case 4:
+                    length = width * height / 2;
+                    OTextureFormat = RenderBase.OTextureFormat.etc1;
+                    break;
+            }
+            // The image data starts at byte 0x80
+            data.Seek(0x80, SeekOrigin.Begin);
+            byte[] buffer = new byte[length];
+            data.Read(buffer, 0, buffer.Length);
+            data.Close();
+
+            // Note: 3DST images are flipped upside-down.
+            // This is intended as the console flips it back and shows it correctly
+            Bitmap bmp = TextureCodec.decode(buffer, width, height, OTextureFormat);
+
+            Bitmap newBmp = new Bitmap(width, height);
+            Graphics gfx = Graphics.FromImage(newBmp);
+            gfx.DrawImage(bmp, new Rectangle(0, 0, width, height), new Rectangle(0, 0, width, height), GraphicsUnit.Pixel);
+            gfx.Dispose();
+
+            return new RenderBase.OTexture(newBmp, "Texture");
+        }
+    }
+}

--- a/Ohana3DS Rebirth/Ohana/Textures/3DST.cs
+++ b/Ohana3DS Rebirth/Ohana/Textures/3DST.cs
@@ -17,7 +17,6 @@ namespace Ohana3DS_Rebirth.Ohana.Textures
 
             // A 3DST image contains the word 'texture' at the beggining of the file, followed by 9 null bytes
             string _3dstMagic = IOUtils.readStringWithLength(input, 7);
-            if (_3dstMagic != "texture") throw new Exception("3DST: Invalid or corrupted file!");
             input.ReadUInt32();
             input.ReadUInt32();
             input.ReadByte();
@@ -27,7 +26,7 @@ namespace Ohana3DS_Rebirth.Ohana.Textures
             ushort height = input.ReadUInt16();
             ushort format = input.ReadUInt16();
 
-            // Depending of the image format, the length of it is calculated differently
+            // Depending of the image format, its length is calculated differently
             int length = 0;
             RenderBase.OTextureFormat OTextureFormat = RenderBase.OTextureFormat.dontCare;
             switch(format)
@@ -41,6 +40,7 @@ namespace Ohana3DS_Rebirth.Ohana.Textures
                     OTextureFormat = RenderBase.OTextureFormat.etc1;
                     break;
             }
+
             // The image data starts at byte 0x80
             data.Seek(0x80, SeekOrigin.Begin);
             byte[] buffer = new byte[length];

--- a/Ohana3DS Rebirth/Ohana/Textures/3DST.cs
+++ b/Ohana3DS Rebirth/Ohana/Textures/3DST.cs
@@ -26,30 +26,39 @@ namespace Ohana3DS_Rebirth.Ohana.Textures
             ushort height = input.ReadUInt16();
             ushort format = input.ReadUInt16();
 
-            // Depending of the image format, its length is calculated differently
-            int length = 0;
-            RenderBase.OTextureFormat OTextureFormat = RenderBase.OTextureFormat.dontCare;
-            switch(format)
-            {
-                case 0:
-                    length = width * height * 4;
-                    OTextureFormat = RenderBase.OTextureFormat.rgba8;
-                    break;
-                case 4:
-                    length = width * height / 2;
-                    OTextureFormat = RenderBase.OTextureFormat.etc1;
-                    break;
-            }
-
             // The image data starts at byte 0x80
             data.Seek(0x80, SeekOrigin.Begin);
-            byte[] buffer = new byte[length];
+            byte[] buffer = new byte[data.Length - 0x80];
             data.Read(buffer, 0, buffer.Length);
             data.Close();
 
             // Note: 3DST images are flipped upside-down.
             // This is intended as the console flips it back and shows it correctly
-            Bitmap bmp = TextureCodec.decode(buffer, width, height, OTextureFormat);
+            Bitmap bmp = null;
+            switch (format)
+            {
+                case 0:
+                    bmp = TextureCodec.decode(buffer, width, height, RenderBase.OTextureFormat.rgba8);
+                    break;
+                case 1:
+                    bmp = TextureCodec.decode(buffer, width, height, RenderBase.OTextureFormat.rgb8);
+                    break;
+                case 2:
+                    bmp = TextureCodec.decode(buffer, width, height, RenderBase.OTextureFormat.a8);
+                    break;
+                case 4:
+                    bmp = TextureCodec.decode(buffer, width, height, RenderBase.OTextureFormat.etc1);
+                    break;
+                case 5:
+                    bmp = TextureCodec.decode(buffer, width, height, RenderBase.OTextureFormat.rgba5551);
+                    break;
+                case 6:
+                    bmp = TextureCodec.decode(buffer, width, height, RenderBase.OTextureFormat.rgb565);
+                    break;
+                case 7:
+                    bmp = TextureCodec.decode(buffer, width, height, RenderBase.OTextureFormat.rgba4);
+                    break;
+            }
 
             Bitmap newBmp = new Bitmap(width, height);
             Graphics gfx = Graphics.FromImage(newBmp);

--- a/Ohana3DS Rebirth/Ohana3DS Rebirth.csproj
+++ b/Ohana3DS Rebirth/Ohana3DS Rebirth.csproj
@@ -260,6 +260,7 @@
     <Compile Include="Ohana\Models\PocketMonsters\PC.cs" />
     <Compile Include="Ohana\Models\PocketMonsters\GfModel.cs" />
     <Compile Include="Ohana\PatriciaTree.cs" />
+    <Compile Include="Ohana\Textures\3DST.cs" />
     <Compile Include="Ohana\Textures\BCLIM.cs" />
     <Compile Include="Ohana\Textures\DMP.cs" />
     <Compile Include="Ohana\FileIO.cs" />


### PR DESCRIPTION
This PR adds support for 3DST file extensions used on the Nintendo Anime Channel application for textures and thumbnails.

**Note:** this doesn't add support for 3DST files from Minecraft for New 3DS, as they use a different implementation and are not inter-compatible with Nintendo ones.